### PR TITLE
Initial support for macOS M1 (arm)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Eclipse (leave checked in)
+# .cproject
+# .project
+# /.launches/
+
+# doxygen output
+/doc/
+
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,43 @@
+# EXIP - Embeddable EXI Processor in C
+
+This is just a placeholder for new information. Refer to the original
+[README.txt](README.txt)
+
+# Developer Information
+
+The following section is for new contributors to EXIP.
+
+## VSCode Support
+
+[VScode](https://code.visualstudio.com/) is supported by adding the [clangd](https://clangd.llvm.org/) plugin to get C Language Server Protocol (LSP) support. Find the official plugin [here](https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd).
+
+
+## Testing Dependency
+
+The Check Unit Test Framework for C for testing. Link to the [Check](https://libcheck.github.io/check/) library. Please see the install notes [here](https://libcheck.github.io/check/web/install.html).
+
+### macOS
+
+Using the following command work to install `Check`:
+
+```sh
+$ brew install check
+```
+
+The macOS `arm` processors have a non-standard include directory so there needs to be an entry into the `compile_flags.txt` file for `clangd` to support the Check library. This is at the root of the project.
+
+Adding architecture specific [code](https://stackoverflow.com/questions/714100/os-detecting-makefile) to the `Makefile` may not be so good but for now it works.
+
+Compiles on macOS M1 using Ventura 13.6.7 and Xcode command line tools.
+
+## Documentation Dependency
+
+In order the make the documentation you need to install [doxygen](https://www.doxygen.nl/).
+
+## macOS
+
+Using the following command work to install `doxygen`:
+
+```sh
+$ brew install doxygen
+```

--- a/build/gcc/Makefile
+++ b/build/gcc/Makefile
@@ -58,6 +58,20 @@ UTILS_BIN_DIR = $(BIN_DIR)/utils
 # Public include directory
 PUBLIC_INCLUDE_DIR = $(PROJECT_ROOT)/include
 
+# Platform specific
+ifeq ($(OS), Windows_NT)
+	# Future support
+else
+	UNAME_S := $(shell uname -s)
+	UNAME_P := $(shell uname -p)
+	ifeq ($(UNAME_S), Darwin)
+		ifeq ($(UNAME_P), arm)
+			INCDIRS += -I/opt/homebrew/include
+			LDFLAGS += -L/opt/homebrew/lib
+		endif
+	endif
+endif
+
 # All directories containing *.c files
 VPATH = $(PROJECT_ROOT)/src/common/src
 VPATH += $(PROJECT_ROOT)/src/contentIO/src
@@ -156,7 +170,7 @@ all: $(BIN_DIR) $(LIB_BIN_DIR) $(LIB_OBJECTS) $(LIB_BIN_DIR)/libexip.a copy_head
 dynlib: COMPILE += -fPIC
 dynlib: clean all $(LIB_BIN_DIR)/libexip.so
 
-# TARGET: Exacute the unit tests
+# TARGET: Execute the unit tests
 check: all $(TESTS_BIN_DIR) $(CHECK_BINS)
 		for i in $(CHECK_BINS); do \
                    $$i $(TESTS_DATA_DIR); \

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -1,0 +1,31 @@
+# Project setup for clangd
+
+# Include dirs
+-I
+include
+-I
+src/common/include
+-I
+src/contentIO/include
+-I
+src/grammar/include
+-I
+src/grammarGen/include
+-I
+src/streamIO/include
+-I
+src/stringTables/include
+-I
+utils/schemaHandling/include
+
+# Platform specific
+# EXIP specific
+-I
+build/gcc/pc
+
+# macOS arm
+-I
+/opt/homebrew/include
+
+# Defines as required for features or conditional compilation
+# -DXXX


### PR DESCRIPTION
Make targets `dist` and `dynlib` will still need to be sorted out. Beginnings of some better cross platform support if even just supported in `Makefile` for the time being.