### PR TITLE
Fix vs 2019 version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         if: startsWith(matrix.os, 'windows-2019')
         uses: microsoft/setup-msbuild@v2
         with:
-          vs-version: '[16.11, 16.12)'
+          vs-version: '[16.11, 16.11)'
 
       - name: Setup (Windows)
         if: startsWith(matrix.os, 'windows-2022')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, macos-13, windows-2019, windows-2022]
+        os: [ubuntu-22.04, macos-13, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -28,12 +28,6 @@ jobs:
             brew install check doxygen
 
       - name: Setup (Windows)
-        if: startsWith(matrix.os, 'windows-2019')
-        uses: microsoft/setup-msbuild@v2
-        with:
-          vs-version: '[16.11, 16.11)'
-
-      - name: Setup (Windows)
         if: startsWith(matrix.os, 'windows-2022')
         uses: microsoft/setup-msbuild@v2
         with:
@@ -44,18 +38,6 @@ jobs:
         run: |
             cd build/gcc
             make TARGET=pc clean all check examples utils doc
-
-      - name: Run tests ${{matrix.os}}
-        if: (startsWith(matrix.os, 'windows-2019'))
-        run: |
-            vcpkg integrate install
-            msbuild build\vs2019\exip.sln -property:Configuration=Debug
-            echo "Run individual tests"
-            build\vs2019\Debug\check_contentio.exe
-            build\vs2019\Debug\check_grammar.exe
-            build\vs2019\Debug\check_streamIO.exe
-            build\vs2019\Debug\check_stringTables.exe
-            echo "Run examples (todo)"
 
       - name: Run tests ${{matrix.os}}
         if: (startsWith(matrix.os, 'windows-2022'))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         if: (startsWith(matrix.os, 'windows-2022'))
         run: |
             vcpkg integrate install
-            msbuild build\vs2022\exip.sln -property:Configuration=Debug
+            msbuild.exe build\vs2022\exip.sln -property:Configuration=Debug
             echo "Run individual tests"
             build\vs2022\Debug\check_contentio.exe
             build\vs2022\Debug\check_grammar.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,6 @@ jobs:
       - name: Setup (Windows)
         if: startsWith(matrix.os, 'windows-2022')
         uses: microsoft/setup-msbuild@v2
-        with:
-          vs-version: '[17.13, 17.14)'
 
       - name: Run tests ${{matrix.os}}
         if: startsWith(matrix.os, 'windows') == false


### PR DESCRIPTION
Checkout v5 broke ci so experimenting now

Latest vs-version is included so don't speciify.
VS 2019 is no longer supported so remove.