### PR TITLE
Add include for stdlib to remove warnings and change Windows to use stdlib function strtoll

### DIFF
--- a/.github/workflows/contiki-ng.yml
+++ b/.github/workflows/contiki-ng.yml
@@ -53,14 +53,14 @@ jobs:
 
       - name: Build contiki-ng
         run: |
-            cd exip/build/gcc
-            echo "Run build and test"
-            make TARGET=zoul clean all
+          cd exip/build/gcc
+          echo "Run build and test"
+          make TARGET=zoul clean all
 
       - name: Verify 32-bit ARM Architecture
         run: |
-            # This proves the build actually produced a 32-bit ARM binary (.a is in bin/lib)
-            echo -n "Binary Specs: "
-            arm-none-eabi-readelf -h -A exip/bin/EXIParser.o \
-              | grep -E "Class:|Machine:|Flags:|Tag_THUMB_ISA_use:|Tag_ABI_VFP_args:" \
-              | xargs
+          # This proves the build actually produced a 32-bit ARM binary (.a is in bin/lib)
+          echo -n "Binary Specs: "
+          arm-none-eabi-readelf -h -A exip/bin/EXIParser.o \
+            | grep -E "Class:|Machine:|Flags:|Tag_THUMB_ISA_use:|Tag_ABI_VFP_args:" \
+            | xargs

--- a/build/vs2022/exipConfig.h
+++ b/build/vs2022/exipConfig.h
@@ -74,7 +74,7 @@
 #define EXIP_MFREE free
 
 //Use MSVS equivalent for strtoll
-#define EXIP_STRTOLL _strtoi64
+// #define EXIP_STRTOLL _strtoi64
 
 /** @def HASH_TABLE_USE
  * 		Whether to use hash table for value partition table when in encoding mode

--- a/include/procTypes.h
+++ b/include/procTypes.h
@@ -296,12 +296,6 @@ typedef EXIP_SMALL_INDEX SmallIndex;
 
 typedef CHAR_TYPE CharType;
 
-
-#ifndef EXIP_STRTOLL
-/** strtoll() function */
-# define EXIP_STRTOLL strtoll
-#endif
-
 /**
  * Represents the length prefixed strings in EXIP
  */

--- a/src/common/src/ASCII_stringManipulate.c
+++ b/src/common/src/ASCII_stringManipulate.c
@@ -230,7 +230,7 @@ errorCode stringToInt64(const String* src, int64_t* number)
 	memcpy(buff, src->str, src->length);
 	buff[src->length] = '\0';
 
-	result = EXIP_STRTOLL(buff, &endPointer, 10);
+	result = strtoll(buff, &endPointer, 10);
 
 	if(result == LLONG_MAX || result == LLONG_MIN || *src->str == *endPointer)
 		return EXIP_INVALID_STRING_OPERATION;


### PR DESCRIPTION
Remove implicit declaration for `strtol` and `strtoll`.
Change windows to use `strtoll` instead of `_strtoi64` and remove `EXIP_STRTOLL` define.