### PR TITLE
Ignore whitespace for now, annotations and other changes for a large schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ packages/
 
 # vcpkg generated
 vcpkg_installed/
+
+bin
+

--- a/src/grammarGen/src/treeTableToGrammars.c
+++ b/src/grammarGen/src/treeTableToGrammars.c
@@ -636,6 +636,10 @@ static errorCode handleElementEl(BuildContext* ctx, QualifiedTreeTableEntry* tre
 			{
 				TRY(getComplexTypeProtoGrammar(ctx, &treeTEntry->entry->child, &pg));
 			}
+			else if(treeTEntry->entry->child.entry->element == ELEMENT_ANNOTATION)
+			{
+    				// Annotations carry no grammar information - skip
+			}			
 			else
 				return EXIP_UNEXPECTED_ERROR;
 
@@ -1398,8 +1402,10 @@ static errorCode getSequenceProtoGrammar(BuildContext* ctx, QualifiedTreeTableEn
 			TRY(getAnyProtoGrammar(ctx, &nextIterator, &particleGrammar));
 		}
 		else
+		{
+			destroyDynArray(&partGrammarTbl.dynArray);
 			return EXIP_UNEXPECTED_ERROR;
-
+		}
 		TRY(addDynEntry(&partGrammarTbl.dynArray, &particleGrammar, &dummyTblIndx));
 		nextIterator.entry = nextIterator.entry->next;
 	}
@@ -1775,16 +1781,19 @@ static errorCode getRestrictionSimpleProtoGrammar(BuildContext* ctx, QualifiedTr
 			// TODO: needs to be implemented. It is also needed for the XML Schema grammars
 			// COMMENT #SCHEMA#: ignore for now
 			DEBUG_MSG(INFO, DEBUG_GRAMMAR_GEN, ("\n>Type facet pattern is not implemented: at %s, line %d.", __FILE__, __LINE__));
-//			return EXIP_NOT_IMPLEMENTED_YET;
 		}
 		else if(tmpEntry->element == ELEMENT_WHITE_SPACE)
 		{
-			SET_TYPE_FACET(newSimpleType.content, TYPE_FACET_WHITE_SPACE);
-			return EXIP_NOT_IMPLEMENTED_YET;
+			// skip whiteSpace
+			// whiteSpace facet is informational only - no grammar impact
 		}
 		else if(tmpEntry->element == ELEMENT_ENUMERATION)
 		{
 			enumCount += 1;
+		}
+		else if(tmpEntry->element == ELEMENT_ANNOTATION)
+		{
+			// skip annotations
 		}
 		else
 			return EXIP_UNEXPECTED_ERROR;
@@ -1888,8 +1897,13 @@ static errorCode getRestrictionSimpleProtoGrammar(BuildContext* ctx, QualifiedTr
 		enumEntry = resEntry->entry->child.entry;
 		while(enumEntry != NULL)
 		{
-			if(enumEntry->element == ELEMENT_ENUMERATION)
+			if(enumEntry->element == ELEMENT_ANNOTATION)
 			{
+				// skip annotations
+			}
+			else if(enumEntry->element == ELEMENT_ENUMERATION)
+			{
+				if(enumIter >= eDef.count) { fprintf(stderr, "ENUM2 OVERFLOW enumIter=%u count=%u\n", enumIter, (unsigned)eDef.count); return EXIP_UNEXPECTED_ERROR; }
 				switch(GET_EXI_TYPE(ctx->schema->simpleTypeTable.sType[typeId].content))
 				{
 					case VALUE_TYPE_STRING:
@@ -1935,9 +1949,9 @@ static errorCode getRestrictionSimpleProtoGrammar(BuildContext* ctx, QualifiedTr
 					default:
 						return EXIP_NOT_IMPLEMENTED_YET;
 				}
+				enumIter++;
 			}
 			enumEntry = enumEntry->next;
-			enumIter++;
 		}
 
 		TRY(addDynEntry(&ctx->schema->enumTable.dynArray, &eDef, &elId));

--- a/src/grammarGen/src/treeTableToGrammars.c
+++ b/src/grammarGen/src/treeTableToGrammars.c
@@ -1903,7 +1903,10 @@ static errorCode getRestrictionSimpleProtoGrammar(BuildContext* ctx, QualifiedTr
 			}
 			else if(enumEntry->element == ELEMENT_ENUMERATION)
 			{
-				if(enumIter >= eDef.count) { fprintf(stderr, "ENUM2 OVERFLOW enumIter=%u count=%u\n", enumIter, (unsigned)eDef.count); return EXIP_UNEXPECTED_ERROR; }
+				if(enumIter >= eDef.count) 
+				{ 
+					return EXIP_UNEXPECTED_ERROR; 
+				}
 				switch(GET_EXI_TYPE(ctx->schema->simpleTypeTable.sType[typeId].content))
 				{
 					case VALUE_TYPE_STRING:

--- a/utils/schemaHandling/exipg.c
+++ b/utils/schemaHandling/exipg.c
@@ -160,7 +160,7 @@ int main(int argc, char *argv[])
 
 	if(strstr(argv[argIndex], "-schema") != NULL)
 	{
-		char *xsdList = argv[argIndex] + 7;
+		char *xsdList = argv[argIndex] + 8;
 
 		parseSchema(xsdList, &schema, mask, maskOpt);
 
@@ -253,7 +253,7 @@ static void parseSchema(char* xsdList, EXIPSchema* schema, unsigned char mask, E
 	errorCode tmp_err_code = EXIP_UNEXPECTED_ERROR;
 	FILE *schemaFile;
 	BinaryBuffer buffer[MAX_XSD_FILES_COUNT]; // up to 10 XSD files
-	char schemaFileName[50];
+	char schemaFileName[2048];
 	unsigned int schemaFilesCount = 0;
 	unsigned int i;
 	char *token;

--- a/utils/schemaHandling/include/schemaOutputUtils.h
+++ b/utils/schemaHandling/include/schemaOutputUtils.h
@@ -21,7 +21,7 @@
 #include "createGrammars.h"
 
 // Maximum number of characters in a variable name buffer
-#define VAR_BUFFER_MAX_LENGTH 200
+#define VAR_BUFFER_MAX_LENGTH 2048
 
 typedef struct
 {

--- a/utils/schemaHandling/output/staticOutputUtils.c
+++ b/utils/schemaHandling/output/staticOutputUtils.c
@@ -65,8 +65,11 @@ void staticStringDefOutput(String* str, char* varName, FILE* out)
 			if(charIter < charMax - 1)
 				fprintf(out, ", ");
 		}
-		strncpy(displayStr, str->str, str->length);
-		displayStr[str->length] = '\0';
+		{ 
+			size_t cpyLen = str->length < (VAR_BUFFER_MAX_LENGTH-1) ? str->length : (VAR_BUFFER_MAX_LENGTH-1); 
+			strncpy(displayStr, str->str, cpyLen); 
+			displayStr[cpyLen] = '\0'; 
+		}
 		fprintf(out, "}; /* %s */\n", displayStr);
 	}
 }
@@ -232,8 +235,8 @@ void staticPrefixOutput(PfxTable* pfxTbl, char* prefix, Index uriId, Deviations 
 void staticLnEntriesOutput(LnTable* lnTbl, char* prefix, Index uriId, Deviations dvis, FILE* out)
 {
 	Index lnIter;
-	char elemGrammar[20];
-	char typeGrammar[20];
+	char elemGrammar[256];
+	char typeGrammar[256];
 
 	if(lnTbl->count + dvis.ln> 0)
 	{


### PR DESCRIPTION
I don't write a lot of PRs so please be gentle.  

I need to use exipg to generate a schema aware exi processor.  the xsd is large. (~7500 complex type and  elements and a bunch of abstract base complex types split across two files).  I uses nagasina to generate .xsd.exi files for the two xsds and fed them into exipg -static -schema=one.xsd.exi,two.xsd.exi exi_proc.c &2>1

I ran into a couple problems with exipg.  

First, crashes. some of the buffers were too small for the xsd filenames on the command line, and some of the internal buffers were too small for some of the rather verbose type names  . 

Second, the two XSDs were loaded up with whitespace and annotation tags which exipg wasn't able to process.

I inflated the buffer sizes and added code to skip annotation and whiteSpace tags. It works for my bloated xsds and thought I should PR this before I got pulled away to a new task so someone else might be able to find value in it....  Or so that someone can tell me there was a simpler way to do this. 

Here's what this PR does

1. Increases buffer sizes to handle large filenames and element names
2. Moves an argIndex inside a while loop so that it is not incremented when an annotation is skipped (skipping the annotation does not allocate memory for it in the dyn array, on cleanup that dyn array gets free'd which results in unallocated memory being free'd, which causes a crash and truncates the output.c file).
3. Adds a string length guard to limit string length to buffer length on a string copy